### PR TITLE
Remove storage implementation section

### DIFF
--- a/draft-bryce-cose-receipts-mmr-profile.md
+++ b/draft-bryce-cose-receipts-mmr-profile.md
@@ -427,7 +427,6 @@ We define `consistent_roots` as
 # Appending a leaf
 
 An algorithm for appending to a tree maintained in post order layout is provided.
-Implementation defined methods for interacting with storage are specified.
 
 ## add_leaf_hash
 
@@ -440,7 +439,7 @@ This process MUST proceed until there are no more completable sub trees.
 Given:
 
 - `f` the leaf value resulting from `H(x)` for the caller defined leaf value `x`
-- `db` an interface supporting the [append](#append) and [get](#get) implementation defined storage methods.
+- `db` an interface supporting `append(entry)` and `get(index)` methods.
 
 And the methods:
 
@@ -482,33 +481,6 @@ We define `add_leaf_hash` as
 
     return i
 ~~~~
-
-## Implementation defined storage methods
-
-The following methods are assumed to be available to the implementation.
-Very minimal requirements are specified.
-
-Informally, the storage must be array like and have no gaps.
-
-### Get
-
-Reads the value from the tree at the supplied index.
-
-The read MUST be consistent with any other calls to Append or Get within the same algorithm invocation.
-
-Get MAY fail for transient reasons.
-
-### Append
-
-Appends new node to storage and returns the index that will be occupied by the node provided to the next call to append.
-
-The implementation MUST guarantee that the results of Append are immediately available to Get calls in the same invocation of the algorithm.
-
-Append MUST return the node `i` identifying the node location which comes next.
-
-The implementation MAY defer commitment to underlying persistent storage.
-
-Append MAY fail for transient reasons.
 
 ## Node values
 

--- a/draft-bryce-cose-receipts-mmr-profile.md
+++ b/draft-bryce-cose-receipts-mmr-profile.md
@@ -439,7 +439,7 @@ This process MUST proceed until there are no more completable sub trees.
 Given:
 
 - `f` the leaf value resulting from `H(x)` for the caller defined leaf value `x`
-- `db` an interface supporting `append(entry)` and `get(index)` methods.
+- `db` an interface supporting `append(entry) -> index` and `get(index) -> entry` methods.
 
 And the methods:
 


### PR DESCRIPTION
Counterpart to https://github.com/robinbryce/draft-bryce-cose-merkle-mountain-range-proofs/pull/21 on the old repo, which was a proposed fix for https://github.com/robinbryce/draft-bryce-cose-merkle-mountain-range-proofs/issues/15.