### PR TITLE
Typo fix, missing "tree" presumed

### DIFF
--- a/draft-bryce-cose-receipts-mmr-profile.md
+++ b/draft-bryce-cose-receipts-mmr-profile.md
@@ -512,7 +512,7 @@ Append MAY fail for transient reasons.
 
 ## Node values
 
-Interior nodes in the MUST prefix the value provided to `H(x)` with `pos`.
+Interior nodes in the tree MUST prefix the value provided to `H(x)` with `pos`.
 
 The value `v` for any interior node MUST be `H(pos || Get(LEFT_CHILD) || Get(RIGHT_CHILD))`
 


### PR DESCRIPTION
See https://github.com/robinbryce/draft-bryce-cose-merkle-mountain-range-proofs/pull/22